### PR TITLE
Various fixes in several screens

### DIFF
--- a/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
+++ b/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
@@ -2711,7 +2711,7 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) / 2, (720 - wsizey)
   <screen flags="wfNoBorder" name="VideoWizard" position="0,0" size="1280,720" backgroundColor="transparent" transparent="0">
     <panel name="N2Template" />
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/icons/wizard.png" zPosition="4" transparent="0" alphatest="blend" />
-    <eLabel font="Regular; 28" position="290,69" size="700,50" halign="center" text="Default settings" backgroundColor="NLPreBlack" foregroundColor="jeaune" transparent="1" zPosition="2" valign="center" />
+    <eLabel font="Regular; 28" position="290,69" size="700,50" halign="center" text="Select video output" backgroundColor="NLPreBlack" foregroundColor="jeaune" transparent="1" zPosition="2" valign="center" />
     <widget name="text" backgroundColor="transpBA" font="Regular; 22" position="330,150" size="785,150" halign="center" valign="center" transparent="1" zPosition="3" />
     <widget source="list" render="Listbox" scrollbarMode="showOnDemand" position="330,330" size="785,210" transparent="1" zPosition="1" backgroundColor="transpBA" foregroundColor="white">
       <convert type="TemplatedMultiContent">
@@ -2729,10 +2729,9 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) / 2, (720 - wsizey)
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,580" size="750,1" scale="1" zPosition="10" alphatest="blend" />
   </screen>
   <!-- Language Wizard -->
-  <screen name="LanguageWizard" flags="wfNoBorder" position="0,0" size="1280,720" backgroundColor="transparent" title="Welcome...">
+  <screen name="LanguageWizard" flags="wfNoBorder" position="0,0" size="1280,720" backgroundColor="transparent" title="Language selection">
     <panel name="N2Template" />
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/icons/wizard.png" zPosition="4" transparent="0" alphatest="blend" />
-    <eLabel font="Regular; 28" position="290,69" size="700,50" halign="center" backgroundColor="NLPreBlack" foregroundColor="jeaune" text="Language Selection" transparent="1" zPosition="2" valign="center" />
     <widget name="text" font="Regular; 22" position="500,600" size="557,50" halign="right" valign="center" transparent="1" zPosition="3" foregroundColor="white" backgroundColor="NLPreBlack" />
     <widget source="languages" render="Listbox" position="324,154" transparent="1" size="795,400" scrollbarMode="showOnDemand" zPosition="1">
       <convert type="TemplatedMultiContent">
@@ -2847,9 +2846,9 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) / 2, (720 - wsizey)
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,140" size="750,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,580" size="750,1" scale="1" zPosition="10" alphatest="blend" />
   </screen>
-  <screen name="NetworkWizard" position="0,0" size="1280,720" title="Welcome..." flags="wfNoBorder" backgroundColor="transparent">
+  <screen name="NetworkWizard" position="0,0" size="1280,720" flags="wfNoBorder" backgroundColor="transparent">
     <panel name="N2Template" />
-    <eLabel font="Regular; 28" position="290,69" size="700,50" halign="center" text="Default settings" backgroundColor="NLPreBlack" foregroundColor="jeaune" transparent="1" zPosition="1" valign="center" />
+    <eLabel font="Regular; 28" position="290,69" size="700,50" halign="center" text="Network setup" backgroundColor="NLPreBlack" foregroundColor="jeaune" transparent="1" zPosition="1" valign="center" />
     <widget name="rc" position="146,122" size="154,474" pixmaps="skin_default/rc.png,skin_default/rcold.png" zPosition="10" alphatest="blend" />
     <widget name="arrowdown" position="203,301" size="37,70" pixmap="skin_default/arrowdown.png" zPosition="11" alphatest="blend" />
     <widget name="arrowdown2" position="203,301" size="37,70" pixmap="skin_default/arrowdown.png" zPosition="11" alphatest="blend" />

--- a/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
+++ b/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
@@ -1246,73 +1246,17 @@
   </screen>
   <!-- Plugin Browser -->
   <screen name="PluginBrowser" position="0,0" size="1280,720" flags="wfNoBorder" backgroundColor="transparent">
-    <eLabel text="Plugin browser" position="251,67" size="777,55" backgroundColor="transpBA" transparent="1" zPosition="0" font="Regular; 28" valign="center" halign="center" noWrap="1" foregroundColor="jeaune" />
+    <panel name="TBTemplate" />
     <widget name="list" enableWrapAround="1" position="330,154" size="790,400" scrollbarMode="showOnDemand" transparent="1" zPosition="1" backgroundColor="transpBA" foregroundColor="white" />
-    <widget name="green" position="540,600" size="200,50" backgroundColor="transpBA" zPosition="1" transparent="1" font="Regular; 22" halign="center" valign="center" />
-    <widget name="red" position="340,600" size="200,50" backgroundColor="transpBA" zPosition="1" transparent="1" font="Regular; 22" halign="center" valign="center" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/fleched.png" position="145,81" size="32,32" transparent="0" zPosition="8" alphatest="on" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/flecheg.png" position="1108,81" size="32,32" transparent="0" zPosition="8" alphatest="on" />
-    <eLabel position="310,129" zPosition="0" size="828,460" backgroundColor="transpBA" transparent="0" font="Regular; 0" foregroundColor="transparent" />
-    <ePixmap name="" pixmap="Satdreamgr-HD-TranspBA/icons/logo.png" position="1080,85" size="24,24" alphatest="blend" zPosition="10" />
-    <eLabel name="" position="140,64" size="1000,60" zPosition="-11" backgroundColor="NLPreBlack" />
-    <eLabel name="" position="140,594" size="1000,60" backgroundColor="NLPreBlack" zPosition="0" />
-    <eLabel name="" position="140,124" size="165,471" backgroundColor="blue" />
-    <eLabel position="151,198" zPosition="1" size="146,310" backgroundColor="transpBA" transparent="0" />
-    <widget source="global.CurrentTime" render="Label" position="140,166" size="165,25" backgroundColor="blue" transparent="1" font="Regular; 22" halign="center" valign="center" foregroundColor="white" zPosition="2">
-      <convert type="ClockToText">Format:%d-%m-%Y</convert>
-    </widget>
-    <widget source="global.CurrentTime" render="Label" position="140,133" size="165,25" backgroundColor="blue" transparent="1" font="Regular; 22" halign="center" valign="center" foregroundColor="white" zPosition="2">
-      <convert type="ClockToText">Format:%A</convert>
-    </widget>
-    <widget source="global.CurrentTime" render="Label" position="140,529" size="110,40" backgroundColor="blue" transparent="1" font="Regular; 32" halign="right" valign="center" foregroundColor="white" zPosition="2">
-      <convert type="ClockToText">Format:%-H:%M</convert>
-    </widget>
-    <widget source="global.CurrentTime" render="Label" position="247,533" size="45,20" backgroundColor="blue" transparent="1" font="Regular; 20" halign="left" valign="center" foregroundColor="jeaune" zPosition="2">
-      <convert type="ClockToText">Format: :%S</convert>
-    </widget>
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/menu/plugins.png" zPosition="4" transparent="0" alphatest="blend" />
-    <eLabel name="" position="340,594" size="200,6" zPosition="1" backgroundColor="red" />
-    <eLabel name="" position="540,594" size="200,6" zPosition="1" backgroundColor="green" />
-    <eLabel name="" position="740,594" size="200,6" zPosition="2" backgroundColor="yellow" />
-    <eLabel name="" position="940,594" size="200,6" zPosition="2" backgroundColor="blue" />
-    <eLabel name="" position="140,594" size="200,6" zPosition="2" backgroundColor="white" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line1.png" position="155,205" size="135,1" scale="1" zPosition="10" alphatest="blend" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line1.png" position="155,500" size="135,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,140" size="750,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,580" size="750,1" scale="1" zPosition="10" alphatest="blend" />
   </screen>
-  <screen flags="wfNoBorder" name="PluginDownloadBrowser" position="0,0" size="1280,720" backgroundColor="transparent">
-    <widget source="Title" render="Label" position="248,71" size="783,50" backgroundColor="NLPreBlack" transparent="1" zPosition="0" font="Regular; 28" valign="center" halign="center" foregroundColor="jeaune" noWrap="1" />
-    <widget enableWrapAround="1" name="list" position="330,155" size="790,400" foregroundColorSelected="white" backgroundColor="transpBA" scrollbarMode="showOnDemand" transparent="0" zPosition="1" />
-    <widget font="Regular; 22" name="text" position="374,236" size="693,50" halign="center" valign="center" transparent="1" zPosition="1" foregroundColor="white" backgroundColor="transpBA" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/fleched.png" position="145,81" size="32,32" transparent="0" zPosition="8" alphatest="on" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/flecheg.png" position="1108,81" size="32,32" transparent="0" zPosition="8" alphatest="on" />
-    <eLabel position="310,129" zPosition="0" size="828,460" backgroundColor="transpBA" transparent="0" font="Regular; 0" foregroundColor="transparent" />
-    <ePixmap name="" pixmap="Satdreamgr-HD-TranspBA/icons/logo.png" position="1080,85" size="24,24" alphatest="blend" zPosition="10" />
-    <eLabel name="" position="140,64" size="1000,60" zPosition="-11" backgroundColor="NLPreBlack" />
-    <eLabel name="" position="140,594" size="1000,60" backgroundColor="NLPreBlack" zPosition="0" />
-    <eLabel name="" position="140,124" size="165,471" backgroundColor="blue" />
-    <eLabel position="151,198" zPosition="1" size="146,310" backgroundColor="transpBA" transparent="0" />
-    <widget source="global.CurrentTime" render="Label" position="140,166" size="165,25" backgroundColor="blue" transparent="1" font="Regular; 22" halign="center" valign="center" foregroundColor="white" zPosition="2">
-      <convert type="ClockToText">Format:%d-%m-%Y</convert>
-    </widget>
-    <widget source="global.CurrentTime" render="Label" position="140,133" size="165,25" backgroundColor="blue" transparent="1" font="Regular; 22" halign="center" valign="center" foregroundColor="white" zPosition="2">
-      <convert type="ClockToText">Format:%A</convert>
-    </widget>
-    <widget source="global.CurrentTime" render="Label" position="140,529" size="110,40" backgroundColor="blue" transparent="1" font="Regular; 32" halign="right" valign="center" foregroundColor="white" zPosition="2">
-      <convert type="ClockToText">Format:%-H:%M</convert>
-    </widget>
-    <widget source="global.CurrentTime" render="Label" position="247,533" size="45,20" backgroundColor="blue" transparent="1" font="Regular; 20" halign="left" valign="center" foregroundColor="jeaune" zPosition="2">
-      <convert type="ClockToText">Format: :%S</convert>
-    </widget>
-    <eLabel name="" position="340,594" size="200,6" zPosition="0" backgroundColor="red" />
-    <eLabel name="" position="540,594" size="200,6" zPosition="1" backgroundColor="green" />
-    <eLabel name="" position="740,594" size="200,6" zPosition="2" backgroundColor="yellow" />
-    <eLabel name="" position="940,594" size="200,6" zPosition="2" backgroundColor="blue" />
-    <eLabel name="" position="140,594" size="200,6" zPosition="2" backgroundColor="white" />
+  <screen name="PluginDownloadBrowser" position="0,0" size="1280,720" flags="wfNoBorder" backgroundColor="transparent">
+    <panel name="TBTemplate" />
+    <widget name="list" enableWrapAround="1" position="330,155" size="790,400" foregroundColorSelected="white" backgroundColor="transpBA" scrollbarMode="showOnDemand" transparent="0" zPosition="1" />
+    <widget name="text" font="Regular; 22" position="374,236" size="693,50" halign="center" valign="center" transparent="1" zPosition="1" foregroundColor="white" backgroundColor="transpBA" />
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/menu/plugins.png" zPosition="4" transparent="0" alphatest="blend" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line1.png" position="155,205" size="135,1" scale="1" zPosition="10" alphatest="blend" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line1.png" position="155,500" size="135,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,140" size="750,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,580" size="750,1" scale="1" zPosition="10" alphatest="blend" />
   </screen>

--- a/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
+++ b/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
@@ -1971,9 +1971,8 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) / 2, (720 - wsizey)
   <!-- Text Box -->
   <screen name="TextBox" title="Message" position="0,0" size="1280,720" flags="wfNoBorder" backgroundColor="transparent">
     <panel name="TBTemplate" />
-    <ePixmap pixmap="Satdreamgr-HD-TranspBA\buttons/key_exit.png" position="331,614" size="40,30" zPosition="1" />
+    <ePixmap pixmap="Satdreamgr-HD-TranspBA/buttons/key_exit.png" position="150,610" size="40,30" zPosition="1" alphatest="blend" />
     <widget name="text" position="330,150" size="790,405" transparent="1" font="Regular; 22" backgroundColor="transpBA" foregroundColor="white" />
-    <eLabel text="'Exit' = Leave message" backgroundColor="transpBA" font="Regular; 22" halign="left" position="376,616" size="160,26" transparent="1" zPosition="1" foregroundColor="white" />
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/iconssc/text.png" zPosition="4" transparent="0" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,140" size="750,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,580" size="750,1" scale="1" zPosition="10" alphatest="blend" />

--- a/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
+++ b/usr/share/enigma2/Satdreamgr-HD-TranspBA/skin.xml
@@ -2314,16 +2314,14 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) / 2, (720 - wsizey)
     <widget name="DescriptionBorder" position="0,0" size="0,0" />
   </screen>
   <screen name="MovieContextMenu" position="0,0" size="1280,720" flags="wfNoBorder" backgroundColor="transparent">
-    <panel name="STBTemplate" />
+    <panel name="TBTemplate" />
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/iconssc/play.png" zPosition="4" transparent="0" alphatest="blend" />
-    <eLabel text="Movielist menu" position="290,69" size="700,50" backgroundColor="NLPreBlack" transparent="1" zPosition="1" font="Regular; 28" valign="center" halign="center" foregroundColor="jeaune" />
     <widget name="menu" position="330,150" size="790,390" itemHeight="30" font="Regular; 24" scrollbarMode="showOnDemand" transparent="1" backgroundColor="transpBA" foregroundColor="white" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,140" size="750,1" scale="1" zPosition="10" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,580" size="750,1" scale="1" zPosition="10" alphatest="blend" />
   </screen>
   <screen name="MovieBrowserConfiguration" position="0,0" size="1280,720" flags="wfNoBorder" backgroundColor="transparent">
-    <panel name="STBTemplate" />
-    <eLabel text="Movie list configuration" position="290,69" size="700,50" backgroundColor="NLPreBlack" transparent="1" zPosition="1" font="Regular; 28" valign="center" halign="center" foregroundColor="jeaune" />
+    <panel name="TBTemplate" />
     <widget name="config" position="330,150" size="790,360" itemHeight="24" font="Regular; 22" transparent="1" scrollbarMode="showOnDemand" backgroundColor="transpBA" />
     <ePixmap name="" position="161,282" size="128,128" pixmap="Satdreamgr-HD-TranspBA/iconssc/movielist.png" zPosition="4" transparent="0" alphatest="blend" />
     <ePixmap pixmap="Satdreamgr-HD-TranspBA/border/line2.png" position="349,140" size="750,1" scale="1" zPosition="10" alphatest="blend" />


### PR DESCRIPTION
Changes include:

1. Fix a typo in Textbox screen that prevented icon from showing and remove obsolete hard-coded message.
2. Use more appropriate titles for some wizard screens.
3. Use titles from python code instead of hard-coded titles for some screens.
4. Use existing skin template for the PluginBrowser screens to simplify code.